### PR TITLE
chore: Register Svelte4 as peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 		"dist"
 	],
 	"peerDependencies": {
-		"svelte": "^3.54.0"
+		"svelte": "^3.54.0 || ^4.0.0"
 	},
 	"devDependencies": {
 		"@sveltejs/adapter-auto": "^2.0.0",


### PR DESCRIPTION
I got below warning when I use this package with Svelte4, but I think we shouldn't get it.

<img width="464" alt="image" src="https://github.com/Rich-Harris/svelte-split-pane/assets/19153718/c3ed3d27-7f2f-4a7b-88b5-154590ac6b2b">
